### PR TITLE
Update makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -31,6 +31,7 @@ dictobj := $(objdir)/sps_dict.o
 all: $(correlappname) $(gainmatchapp) $(calibrateapp)
 
 $(correlappname): $(dictobj) $(objects)
+	mkdir -p $(bindir)
 	$(CXX) -o $@ $^ $(LDFLAGS)
 	cp $(srcdir)/*.pcm $(bindir)
 
@@ -47,6 +48,7 @@ $(calibrateobj): $(calibratesrc)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ -c $^
 
 $(dictobj): $(dict)
+	mkdir -p $(objdir)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ -c $^
 	$(CXX) $(CXXFLAGS) $@ -shared -o $(dictlib).so $(LDFLAGS)
 


### PR DESCRIPTION
As is, one needs to create ./bin and ./objs directories at the "root" (top-most) directory in oder for make to work correctly. The proposed changes added two lines that will create those directories for the user. Note that the -p switch is there to create a the path if it does not exist. In the man mkdir pages, one can see the description of -p is as follow: no error if existing, make parent directories as needed.